### PR TITLE
Fixed ReDoS (Regex Denial of Service)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,7 @@
     "mocha": "^2.0.1",
     "pragmatist": "^1.9.7"
   },
-  "dependencies": {}
+  "dependencies": {
+    "re2": "^1.15.4"
+  }
 }

--- a/src/url-regexp.js
+++ b/src/url-regexp.js
@@ -1,7 +1,8 @@
 let URLRegEx,
     URLRegExp,
     many,
-    one;
+    one,
+    RE2 = require('re2');
 
 URLRegExp = {};
 
@@ -55,8 +56,8 @@ URLRegEx =
     // resource path
     '(?:/\\S*)?';
 
-one = new RegExp('^' + URLRegEx + '$', 'i');
-many = new RegExp(URLRegEx, 'ig');
+one = new RE2('^' + URLRegEx + '$', 'i');
+many = new RE2(URLRegEx, 'ig');
 
 URLRegExp.validate = (inputString) => {
     return one.test(inputString);


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-url-regexp

### ⚙️ Description *

The project `url-regexp` was validating URLs with a regex vulnerable to **ReDoS** (Regex Denial of Service).

### 💻 Technical Description *

The implemented Regex patterns to validate URLs are vulnerable to ReDoS:

```javascript
(?:(?:https?|ftp)://)' +

// user:pass authentication
'(?:\\S+(?::\\S*)?@)?' +

'(?:' +
    // IP address exclusion - private & local networks
    // Reference: https://www.arin.net/knowledge/address_filters.html

    // filter 10.*.*.* and 127.*.*.* adresses
    '(?!(?:10|127)(?:\\.\\d{1,3}){3})' +

    // filter 169.254.*.* and 192.168.*.*
    '(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})' +

    // filter 172.16.0.0 - 172.31.255.255
    // TODO: add test to validate that it invalides address in 16-31 range
    '(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})' +

    // IP address dotted notation octets
    // excludes loopback network 0.0.0.0
    // excludes reserved space >= 224.0.0.0
    // excludes network & broacast addresses
    // (first & last IP address of each class)

    // filter 1. part for 1-223
    '(?:22[0-3]|2[01]\\d|[1-9]\\d?|1\\d\\d)' +
    // filter 2. and 3. part for 0-255
    '(?:\\.(?:25[0-5]|2[0-4]\\d|1?\\d{1,2})){2}' +
    // filter 4. part for 1-254
    '(?:\\.(?:25[0-4]|2[0-4]\\d|1\\d\\d|[1-9]\\d?))' +
'|' +
    // host name
    '(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)' +

    // domain name
    '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*' +

    // TLD identifier
    '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))' +
')' +

// port number
'(?::\\d{2,5})?' +

// resource path
'(?:/\\S*)?
```

Using a long string to make it pass through this regex will lead to **Denial of Service**.

### 🐛 Proof of Concept (PoC) *

**Ref:** https://github.com/gajus/url-regexp/issues/8

### 🔥 Proof of Fix (PoF) *

As the used Regex is perfect to validate URLs but just vulnerable to ReDoS, I implemented [`node-re2`](https://www.npmjs.com/package/re2) instead of the JavaScript `RegExp()` function as `re2` can convert a vulnerable Regex pattern to a safe one preventing any backtracking regular expressions/attacks.

:books: **Reference:** https://www.npmjs.com/package/re2#standard-features

### 👍 User Acceptance Testing (UAT)

Replaced the usage of `RegExp()` function with a safer regex binding [`node-re2`](https://www.npmjs.com/package/re2#standard-features).
